### PR TITLE
Require "RedAlert" instead of "redalert"

### DIFF
--- a/lib/redpotion.rb
+++ b/lib/redpotion.rb
@@ -7,7 +7,7 @@ end
 require 'ruby_motion_query'
 require 'ProMotion'
 require 'motion_print'
-require 'redalert'
+require 'RedAlert'
 
 lib_dir_path = File.dirname(File.expand_path(__FILE__))
 Motion::Project::App.setup do |app|


### PR DESCRIPTION
When creating a new redpotion (v1.3) project, it always failed for me when it does rake pod:install with the following error:

```
cannot load such file -- redalert
```

I changed it to "RedAlert" in lib/redpotion.rb and everything worked as expected.
